### PR TITLE
fix: use automatic runtime and fix for mono repos

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const path = require('path');
 
 const getBabelPlugins = (options) => {
   let reactNativeWeb = 'react-native-web';
@@ -8,25 +9,29 @@ const getBabelPlugins = (options) => {
   return [reactNativeWeb];
 };
 
-const getModulesToTranspile = (options) => {
-  if (options.modulesToTranspile && Array.isArray(options.modulesToTranspile)) {
-    return options.modulesToTranspile.map((moduleName) => {
-      // returns the path to the entry point file like addon-react-native-web/node_modules/react-native-reanimated/lib/Animated.js'
-      const fullPath = require.resolve(moduleName);
+const getModule = (name) => path.join('node_modules', name);
 
-      const stringToFind = `node_modules/${moduleName}/`;
+// copied from https://github.com/expo/expo-cli/blob/master/packages/webpack-config/src/loaders/createBabelLoader.ts
+const DEFAULT_INCLUDES = [
+  getModule('react-native'),
+  getModule('react-navigation'),
+  getModule('expo'),
+  getModule('unimodules'),
+  getModule('@react'),
+  getModule('@expo'),
+  getModule('@use-expo'),
+  getModule('@unimodules'),
+  getModule('native-base'),
+  getModule('styled-components'),
+];
 
-      // remove everything after 'node_modules/module_name/'
-      const adjustedPath = fullPath.substring(
-        0,
-        fullPath.indexOf(stringToFind) + stringToFind.length,
-      );
-
-      return adjustedPath;
-    });
-  }
-  return [];
-};
+const DEFAULT_EXCLUDES = [
+  '/node_modules',
+  '/bower_components',
+  '/.expo/',
+  // Prevent transpiling webpack generated files.
+  '(webpack)',
+];
 
 module.exports = {
   babel: async (config, options) => ({
@@ -49,31 +54,51 @@ module.exports = {
       }),
     );
 
-    const modulesToTranspile = getModulesToTranspile(options);
+    const babelPlugins = getBabelPlugins(options);
+    const root = options?.projectRoot ?? process.cwd();
+    const modules = [...DEFAULT_INCLUDES, ...options.modulesToTranspile];
 
-    if (modulesToTranspile.length > 0) {
-      const babelPlugins = getBabelPlugins(options);
+    // fix for uncompiled react-native dependencies
+    config.module.rules.push({
+      test: /\.(js|jsx|ts|tsx)$/,
+      loader: 'babel-loader',
+      // include logic copied from https://github.com/expo/expo-cli/blob/master/packages/webpack-config/src/loaders/createBabelLoader.ts
+      include(filename) {
+        if (!filename) {
+          return false;
+        }
 
-      // fix for uncompiled react-native dependencies
-      config.module.rules.push({
-        test: /\.(js|jsx|ts|tsx)$/,
-        loader: 'babel-loader',
-        include: modulesToTranspile,
-        options: {
-          presets: [
-            '@babel/env',
-            [
-              '@babel/preset-react',
-              {
-                runtime: 'automatic',
-              },
-            ],
-            'module:metro-react-native-babel-preset',
+        for (const possibleModule of modules) {
+          if (filename.includes(path.normalize(possibleModule))) {
+            return true;
+          }
+        }
+
+        if (filename.includes(root)) {
+          for (const excluded of DEFAULT_EXCLUDES) {
+            if (filename.includes(path.normalize(excluded))) {
+              return false;
+            }
+          }
+          return true;
+        }
+        return false;
+      },
+      options: {
+        root,
+        presets: [
+          '@babel/env',
+          'module:metro-react-native-babel-preset',
+          [
+            '@babel/preset-react',
+            {
+              runtime: 'automatic',
+            },
           ],
-          plugins: ['@babel/plugin-proposal-class-properties', ...babelPlugins],
-        },
-      });
-    }
+        ],
+        plugins: [...babelPlugins, '@babel/plugin-proposal-class-properties'],
+      },
+    });
 
     config.resolve.extensions = ['.web.js', ...config.resolve.extensions];
 

--- a/preset.js
+++ b/preset.js
@@ -87,8 +87,12 @@ module.exports = {
       options: {
         root,
         presets: [
-          '@babel/env',
-          'module:metro-react-native-babel-preset',
+          [
+            'module:metro-react-native-babel-preset',
+            {
+              useTransformReactJSXExperimental: true,
+            },
+          ],
           [
             '@babel/preset-react',
             {

--- a/preset.js
+++ b/preset.js
@@ -62,7 +62,12 @@ module.exports = {
         options: {
           presets: [
             '@babel/env',
-            '@babel/preset-react',
+            [
+              '@babel/preset-react',
+              {
+                runtime: 'automatic',
+              },
+            ],
             'module:metro-react-native-babel-preset',
           ],
           plugins: ['@babel/plugin-proposal-class-properties', ...babelPlugins],

--- a/stories/libraries/Gesture/Draggable/Draggable.stories.tsx
+++ b/stories/libraries/Gesture/Draggable/Draggable.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { StyleSheet, Text, View } from 'react-native';
 import { Draggable } from './Draggable';

--- a/stories/libraries/NativeBase/AppBar.stories.tsx
+++ b/stories/libraries/NativeBase/AppBar.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { AppBar } from './AppBar';
 import { NativeBaseProvider } from 'native-base';

--- a/stories/libraries/NativeBase/AppBar.tsx
+++ b/stories/libraries/NativeBase/AppBar.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Icon, IconButton, StatusBar, Text } from 'native-base';
-import React from 'react';
+
 import { FavoriteIcon } from '../Svg/FavoriteIcon';
 import { MenuIcon } from '../Svg/MenuIcon';
 import { MoreIcon } from '../Svg/MoreIcon';

--- a/stories/libraries/Paper/Card.stories.tsx
+++ b/stories/libraries/Paper/Card.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { StyleSheet, View } from 'react-native';
 import { DefaultTheme, Provider as PaperProvider } from 'react-native-paper';

--- a/stories/libraries/Paper/Card.tsx
+++ b/stories/libraries/Paper/Card.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Avatar,
   Button,

--- a/stories/libraries/Reanimated/Box.tsx
+++ b/stories/libraries/Reanimated/Box.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
   useSharedValue,

--- a/stories/libraries/Svg/FavoriteIcon.tsx
+++ b/stories/libraries/Svg/FavoriteIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Path, Svg } from 'react-native-svg';
 
 export const FavoriteIcon = ({ color = 'white', ...props }) => (

--- a/stories/libraries/Svg/FolderIcon.tsx
+++ b/stories/libraries/Svg/FolderIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Svg, Path } from 'react-native-svg';
 
 interface FolderProps {

--- a/stories/libraries/Svg/MenuIcon.tsx
+++ b/stories/libraries/Svg/MenuIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Svg, Path } from 'react-native-svg';
 
 export const MenuIcon = ({ color = 'white', ...props }) => (

--- a/stories/libraries/Svg/MoreIcon.tsx
+++ b/stories/libraries/Svg/MoreIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Svg, { Path } from 'react-native-svg';
 
 export const MoreIcon = ({ color = 'white', ...props }) => (

--- a/stories/libraries/Svg/SearchIcon.tsx
+++ b/stories/libraries/Svg/SearchIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Svg, { Path } from 'react-native-svg';
 
 export const SearchIcon = ({ color = 'white', ...props }) => (

--- a/stories/template/Button.stories.tsx
+++ b/stories/template/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
-import React from 'react';
+
 import { View, StyleSheet } from 'react-native';
 import { Button } from './Button';
 

--- a/stories/template/Button.tsx
+++ b/stories/template/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StyleProp, ViewStyle, TouchableOpacity, Text } from 'react-native';
 
 import styles from './button.styles';

--- a/stories/template/Header.tsx
+++ b/stories/template/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from './Button';
 import styles from './header.styles';
 import { H1, Header as HeaderView } from '@expo/html-elements';

--- a/stories/template/Page.tsx
+++ b/stories/template/Page.tsx
@@ -8,7 +8,7 @@ import {
   Strong,
   UL,
 } from '@expo/html-elements';
-import React from 'react';
+
 import { View, Text } from 'react-native';
 import Svg, { G, Path } from 'react-native-svg';
 


### PR DESCRIPTION
- i've removed import react in all places and 
- added the automatic runtime option for babel
- adjusted the includes to work better for mono repo (based on expo webpack config)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.8-canary.13.d8a51bb.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-react-native-web@0.0.8-canary.13.d8a51bb.0
  # or 
  yarn add @storybook/addon-react-native-web@0.0.8-canary.13.d8a51bb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
