### PR TITLE
fix crash if modulesToTranspile undefined

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -56,7 +56,7 @@ module.exports = {
 
     const babelPlugins = getBabelPlugins(options);
     const root = options?.projectRoot ?? process.cwd();
-    const modules = [...DEFAULT_INCLUDES, ...options.modulesToTranspile];
+    const modules = [...DEFAULT_INCLUDES, ...(options.modulesToTranspile || [])];
 
     // fix for uncompiled react-native dependencies
     config.module.rules.push({


### PR DESCRIPTION
Hi,

This PR aims to fix a crash occuring when `modulesToTranspile` option is `undefined` :
`TypeError: options.modulesToTranspile is not iterable`

