### PR TITLE
fix: allow for empty options

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -56,7 +56,10 @@ module.exports = {
 
     const babelPlugins = getBabelPlugins(options);
     const root = options?.projectRoot ?? process.cwd();
-    const modules = [...DEFAULT_INCLUDES, ...(options.modulesToTranspile || [])];
+    const modules = [
+      ...DEFAULT_INCLUDES,
+      ...(options?.modulesToTranspile || []),
+    ];
 
     // fix for uncompiled react-native dependencies
     config.module.rules.push({


### PR DESCRIPTION
allow undefined options object
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.10-canary.16.eabe0d9.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-react-native-web@0.0.10-canary.16.eabe0d9.0
  # or 
  yarn add @storybook/addon-react-native-web@0.0.10-canary.16.eabe0d9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
