### PR TITLE
fix: use target for running action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
 
 # List of jobs
 jobs:


### PR DESCRIPTION
Should enable forked PRs to run the chromatic action.