### PR TITLE
fix: prioritise .web.(jsx|ts|tsx) extension if available

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -106,7 +106,12 @@ const webpackFinal = async (config: any, options: Options) => {
     },
   });
 
-  config.resolve.extensions = ['.web.js', ...config.resolve.extensions];
+  config.resolve.extensions = [
+    '.web.js',
+    '.web.jsx',
+    '.web.ts',
+    '.web.tsx',
+    ...config.resolve.extensions];
 
   return config;
 };


### PR DESCRIPTION
Thanks for the great plugin! This PR aims to add priority for picking .web(.jsx|.ts|.tsx) files. This can be helpful when working with typescript and jsx extensions.