### PR TITLE
fix: add the suggested process.env plugin to the config

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -55,6 +55,9 @@ const webpackFinal = async (config: any, options: Options) => {
     }),
   );
 
+  // plugin suggested in reanimated docs https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/web-support/
+  config.plugins.push(new webpack.DefinePlugin({ process: { env: {} } }));
+
   const babelPlugins = getBabelPlugins(options);
   const root = options.projectRoot ?? process.cwd();
   const userModules = options.modulesToTranspile?.map(getModule) ?? [];
@@ -111,7 +114,8 @@ const webpackFinal = async (config: any, options: Options) => {
     '.web.jsx',
     '.web.ts',
     '.web.tsx',
-    ...config.resolve.extensions];
+    ...config.resolve.extensions,
+  ];
 
   return config;
 };


### PR DESCRIPTION
When testing with the new version of gesture handler and reanimated I found that this plugin was needed for gesture handler to pick up on the worklet function see this issue https://github.com/software-mansion/react-native-gesture-handler/issues/1754

This change adds the suggested plugin from the reanimated documentation
https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/web-support/

```
Published canary version: 0.0.15-canary.5fa51bf.0
```