### PR TITLE
feat: add example for gradient

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "styled-components": "^5.3.1",
     "styled-system": "^5.1.5",
     "typescript": "^4.2.4",
-    "zx": "^1.14.1"
+    "zx": "^1.14.1",
+    "expo-linear-gradient": "^11.0.0"
   },
   "peerDependencies": {
     "@storybook/addons": "^6 || 6.4.0-rc.1",

--- a/stories/libraries/expo-linear-gradient/Gradient.stories.tsx
+++ b/stories/libraries/expo-linear-gradient/Gradient.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentMeta } from '@storybook/react';
+
+import { Gradient } from './Gradient';
+
+export default {
+  title: 'libraries/Expo gradient/Gradient',
+  component: Gradient,
+} as ComponentMeta<typeof Gradient>;
+
+export const Basic = {
+  args: {
+    text: 'Gradient example',
+  },
+};

--- a/stories/libraries/expo-linear-gradient/Gradient.tsx
+++ b/stories/libraries/expo-linear-gradient/Gradient.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export function Gradient({ text }: { text: string }) {
+  return (
+    <View>
+      <LinearGradient
+        // Background Linear Gradient
+        colors={['rgba(0,0,0,0.8)', 'transparent']}
+        style={styles.background}
+      />
+      <LinearGradient
+        // Button Linear Gradient
+        colors={['#4c669f', '#3b5998', '#192f6a']}
+        style={styles.button}
+      >
+        <Text style={styles.text}>{text}</Text>
+      </LinearGradient>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  background: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    height: 300,
+  },
+  button: {
+    padding: 15,
+    alignItems: 'center',
+    borderRadius: 5,
+  },
+  text: {
+    backgroundColor: 'transparent',
+    fontSize: 15,
+    color: '#fff',
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8162,6 +8162,11 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+expo-linear-gradient@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-11.0.0.tgz#88605aad93ee73c32110e83e89ef17bb13c330b5"
+  integrity sha512-OVzmsz5y+NxX4XvtQhKAQCdakVaAwFB0ajYlcT50zl1MKU33LrBa8hxSe3qo8CCGSZSfjdfzGvyZ1cf12BXI9Q==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.npmjs.org/express/-/express-4.17.1.tgz"


### PR DESCRIPTION
when attempting to reproduce the issue #30 I added the gradient example.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.17-canary.31.d996bae.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-react-native-web@0.0.17-canary.31.d996bae.0
  # or 
  yarn add @storybook/addon-react-native-web@0.0.17-canary.31.d996bae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
