### PR TITLE
Remove builder config from main.js

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,9 +17,6 @@ module.exports = {
     },
     '@storybook/addon-essentials',
   ],
-  core: {
-    builder: 'webpack5',
-  },
   framework: {
     name: '@storybook/react-webpack5',
     options: { fastRefresh: true },


### PR DESCRIPTION
Not needed now that we're using v7 frameworks and actually wrong in v7 because it should be `@storybook/builder-webpack5` if we were going to configure it manually 😉 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.20--canary.54.c33318c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-react-native-web@0.0.20--canary.54.c33318c.0
  # or 
  yarn add @storybook/addon-react-native-web@0.0.20--canary.54.c33318c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
