### PR TITLE
fix: namespace from babel plugin shouldnt be required

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,7 +12,10 @@ module.exports = {
           'react-native-vector-icons',
         ],
         modulesToAlias: { 'victory-native': 'victory' },
-        babelPlugins: ['react-native-reanimated/plugin'],
+        babelPlugins: [
+          '@babel/plugin-proposal-export-namespace-from',
+          'react-native-reanimated/plugin',
+        ],
       },
     },
     '@storybook/addon-essentials',

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -102,11 +102,7 @@ const webpackFinal = async (config: any, options: Options) => {
           },
         ],
       ],
-      plugins: [
-        ...babelPlugins,
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-proposal-export-namespace-from',
-      ],
+      plugins: [...babelPlugins, '@babel/plugin-proposal-class-properties'],
     },
   });
 


### PR DESCRIPTION
this plugin is only needed when you use reanimated so it shouldn't be included unless the user adds it